### PR TITLE
✨ Allow for an asymmetric public key encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ docker run -it \
 
 ### Advanced Usage
 
-Example with different region, different S3 storage class, different signature version and call to S3-compatible service (different endpoint url)
+Example with different region, different S3 storage class, different signature version and call to S3-compatible
+service (different endpoint url)
 
 ```shell
 docker run -it \
@@ -42,7 +43,8 @@ docker run -it \
 
 ### Encryption
 
-You can optionally encrypt your backup using GnuPG. To do so, set ENCRYPTION_KEY.
+You can optionally encrypt your backup using GnuPG. To do so, set ENCRYPTION_KEY. This would encrypt the backup with the
+passphrase "your_secret_passphrase". The cypher algorithm used is AES256.
 
 ```shell
 docker run -it \
@@ -51,6 +53,37 @@ docker run -it \
       -e BUCKET_NAME=backups \
       -e BACKUP_NAME=backup \
       -e ENCRYPTION_KEY=your_secret_passphrase
+      -v /path/to/backup:/backup dokku/s3backup
+```
+
+You can also use a GPG public key to encrypt the backup. To do so, set ENCRYPTION_KEY to the public key. This would
+encrypt the backup with the public key. **The backup can only be decrypted with the corresponding private key**, making
+it impossible to encrypt your data even if the backups and all the configuration files are compromised.
+
+```shell
+docker run -it \
+      -e AWS_ACCESS_KEY_ID=ID \
+      -e AWS_SECRET_ACCESS_KEY=KEY \
+      -e BUCKET_NAME=backups \
+      -e BACKUP_NAME=backup \
+      -e ENCRYPT_WITH_PUBLIC_KEY_ID=public_key_id \
+      -v /path/to/backup:/backup dokku/s3backup
+```
+
+In the above command, replace `public_key_id` with the ID (or, even better, the fingerprint) of your GPG public key. The
+backup will be encrypted using this
+public key and can only be decrypted with the corresponding private key. Please note that the public key must be
+available on the keyserver specified by the KEYSERVER environment variable. By default, this is set
+to `hkp://keyserver.ubuntu.com` and can be overridden by setting the KEYSERVER environment variable:
+
+```shell
+docker run -it \
+      -e AWS_ACCESS_KEY_ID=ID \
+      -e AWS_SECRET_ACCESS_KEY=KEY \
+      -e BUCKET_NAME=backups \
+      -e BACKUP_NAME=backup \
+      -e ENCRYPT_WITH_PUBLIC_KEY_ID=public_key_id \
+      -e KEYSERVER=hkp://pgp.mit.edu \
       -v /path/to/backup:/backup dokku/s3backup
 ```
 

--- a/backup.sh
+++ b/backup.sh
@@ -13,7 +13,6 @@ fi
 AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-null}"
 AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-null}"
 AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-null}"
-S3_STORAGE_CLASS="${S3_STORAGE_CLASS:-STANDARD}"
 
 BACKUP_NAME="${BACKUP_NAME:-backup}"
 BUCKET_NAME="${BUCKET_NAME:-null}"
@@ -27,6 +26,11 @@ TIMESTAMP="$(date -u "+%Y-%m-%d-%H-%M-%S")"
 # Build endpoint parameter if endpoint given
 if [[ -n "$ENDPOINT_URL" ]]; then
   ENDPOINT_URL_PARAMETER="--endpoint-url=$ENDPOINT_URL"
+fi
+
+# Add the StorageClass parameter if specified
+if [[ -n "$S3_STORAGE_CLASS" ]]; then
+  S3_STORAGE_CLASS_PARAMETER="--storage-class=$S3_STORAGE_CLASS"
 fi
 
 # Setup AWS signature version if specified
@@ -57,10 +61,10 @@ encrypt_stream() {
 upload_to_s3() {
   if [[ "$1" == "encrypted" ]]; then
     # shellcheck disable=SC2086
-    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz.gpg" --storage-class $S3_STORAGE_CLASS
+    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz.gpg" $S3_STORAGE_CLASS_PARAMETER
   else
     # shellcheck disable=SC2086
-    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz" --storage-class $S3_STORAGE_CLASS
+    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz" $S3_STORAGE_CLASS_PARAMETER
   fi
 }
 

--- a/backup.sh
+++ b/backup.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 
 # Check if backup directory exists
 if [[ ! -d "/backup" ]]; then
-  echo "Please mount a directory to backup with -v /backup:/backup"
-  exit 1
+	echo "Please mount a directory to backup with -v /backup:/backup"
+	exit 1
 fi
 
 # Set default values for Amazon S3 info
@@ -25,17 +25,17 @@ TIMESTAMP="$(date -u "+%Y-%m-%d-%H-%M-%S")"
 
 # Build endpoint parameter if endpoint given
 if [[ -n "$ENDPOINT_URL" ]]; then
-  ENDPOINT_URL_PARAMETER="--endpoint-url=$ENDPOINT_URL"
+	ENDPOINT_URL_PARAMETER="--endpoint-url=$ENDPOINT_URL"
 fi
 
 # Add the StorageClass parameter if specified
 if [[ -n "$S3_STORAGE_CLASS" ]]; then
-  S3_STORAGE_CLASS_PARAMETER="--storage-class=$S3_STORAGE_CLASS"
+	S3_STORAGE_CLASS_PARAMETER="--storage-class=$S3_STORAGE_CLASS"
 fi
 
 # Setup AWS signature version if specified
 if [[ -n "$AWS_SIGNATURE_VERSION" ]]; then
-  aws configure set default.s3.signature_version "$AWS_SIGNATURE_VERSION"
+	aws configure set default.s3.signature_version "$AWS_SIGNATURE_VERSION"
 fi
 
 # Set target directory for backup
@@ -43,56 +43,56 @@ TARGET="backup/"
 
 # Function to create a tar archive of the target directory
 create_tar_archive() {
-  tar --create --gzip --file - "$TARGET"
+	tar --create --gzip --file - "$TARGET"
 }
 
 # Function to encrypt the input stream
 encrypt_stream() {
-  if [[ "$1" == "public_key" ]]; then
-    gpg --batch --no-tty --quiet --encrypt --always-trust --recipient "$ENCRYPT_WITH_PUBLIC_KEY_ID"
-  elif [[ "$1" == "encryption_key" ]]; then
-    gpg --batch --no-tty --quiet --symmetric --cipher-algo AES256 --passphrase "$ENCRYPTION_KEY"
-  else
-    cat
-  fi
+	if [[ "$1" == "public_key" ]]; then
+		gpg --batch --no-tty --quiet --encrypt --always-trust --recipient "$ENCRYPT_WITH_PUBLIC_KEY_ID"
+	elif [[ "$1" == "encryption_key" ]]; then
+		gpg --batch --no-tty --quiet --symmetric --cipher-algo AES256 --passphrase "$ENCRYPTION_KEY"
+	else
+		cat
+	fi
 }
 
 # Function to upload backup to S3
 upload_to_s3() {
-  if [[ "$1" == "encrypted" ]]; then
-    # shellcheck disable=SC2086
-    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz.gpg" $S3_STORAGE_CLASS_PARAMETER
-  else
-    # shellcheck disable=SC2086
-    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz" $S3_STORAGE_CLASS_PARAMETER
-  fi
+	if [[ "$1" == "encrypted" ]]; then
+		# shellcheck disable=SC2086
+		aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz.gpg" $S3_STORAGE_CLASS_PARAMETER
+	else
+		# shellcheck disable=SC2086
+		aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz" $S3_STORAGE_CLASS_PARAMETER
+	fi
 }
 
 # Perform backup based on encryption method
 if [[ -n "$ENCRYPT_WITH_PUBLIC_KEY_ID" ]]; then
-  if gpg --quiet --keyserver "$KEYSERVER" --recv-keys "$ENCRYPT_WITH_PUBLIC_KEY_ID"; then
-    if create_tar_archive | encrypt_stream "public_key" | upload_to_s3 "encrypted"; then
-      echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
-    else
-      echo "Backup of $TARGET has failed. Please investigate the issue."
-      exit 1
-    fi
-  else
-    echo "Error: Failed to retrieve the public key from the keyserver."
-    exit 1
-  fi
+	if gpg --quiet --keyserver "$KEYSERVER" --recv-keys "$ENCRYPT_WITH_PUBLIC_KEY_ID"; then
+		if create_tar_archive | encrypt_stream "public_key" | upload_to_s3 "encrypted"; then
+			echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+		else
+			echo "Backup of $TARGET has failed. Please investigate the issue."
+			exit 1
+		fi
+	else
+		echo "Error: Failed to retrieve the public key from the keyserver."
+		exit 1
+	fi
 elif [[ -n "$ENCRYPTION_KEY" ]]; then
-  if create_tar_archive | encrypt_stream "encryption_key" | upload_to_s3 "encrypted"; then
-    echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
-  else
-    echo "Backup of $TARGET has failed. Please investigate the issue."
-    exit 1
-  fi
+	if create_tar_archive | encrypt_stream "encryption_key" | upload_to_s3 "encrypted"; then
+		echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+	else
+		echo "Backup of $TARGET has failed. Please investigate the issue."
+		exit 1
+	fi
 else
-  if create_tar_archive | encrypt_stream "no_encryption" | upload_to_s3 "unencrypted"; then
-    echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
-  else
-    echo "Backup of $TARGET has failed. Please investigate the issue."
-    exit 1
-  fi
+	if create_tar_archive | encrypt_stream "no_encryption" | upload_to_s3 "unencrypted"; then
+		echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+	else
+		echo "Backup of $TARGET has failed. Please investigate the issue."
+		exit 1
+	fi
 fi

--- a/backup.sh
+++ b/backup.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 
 # Check if backup directory exists
 if [[ ! -d "/backup" ]]; then
-	echo "Please mount a directory to backup with -v /backup:/backup"
-	exit 1
+  echo "Please mount a directory to backup with -v /backup:/backup"
+  exit 1
 fi
 
 # Set default values for Amazon S3 info
@@ -25,17 +25,17 @@ TIMESTAMP="$(date -u "+%Y-%m-%d-%H-%M-%S")"
 
 # Build endpoint parameter if endpoint given
 if [[ -n "$ENDPOINT_URL" ]]; then
-	ENDPOINT_URL_PARAMETER="--endpoint-url=$ENDPOINT_URL"
+  ENDPOINT_URL_PARAMETER="--endpoint-url=$ENDPOINT_URL"
 fi
 
 # Add the StorageClass parameter if specified
 if [[ -n "$S3_STORAGE_CLASS" ]]; then
-	S3_STORAGE_CLASS_PARAMETER="--storage-class=$S3_STORAGE_CLASS"
+  S3_STORAGE_CLASS_PARAMETER="--storage-class=$S3_STORAGE_CLASS"
 fi
 
 # Setup AWS signature version if specified
 if [[ -n "$AWS_SIGNATURE_VERSION" ]]; then
-	aws configure set default.s3.signature_version "$AWS_SIGNATURE_VERSION"
+  aws configure set default.s3.signature_version "$AWS_SIGNATURE_VERSION"
 fi
 
 # Set target directory for backup
@@ -43,56 +43,56 @@ TARGET="backup/"
 
 # Function to create a tar archive of the target directory
 create_tar_archive() {
-	tar --create --gzip --file - "$TARGET"
+  tar --create --gzip --file - "$TARGET"
 }
 
 # Function to encrypt the input stream
 encrypt_stream() {
-	if [[ "$1" == "public_key" ]]; then
-		gpg --batch --no-tty --quiet --encrypt --always-trust --recipient "$ENCRYPT_WITH_PUBLIC_KEY_ID"
-	elif [[ "$1" == "encryption_key" ]]; then
-		gpg --batch --no-tty --quiet --symmetric --cipher-algo AES256 --passphrase "$ENCRYPTION_KEY"
-	else
-		cat
-	fi
+  if [[ "$1" == "public_key" ]]; then
+    gpg --batch --no-tty --quiet --encrypt --always-trust --recipient "$ENCRYPT_WITH_PUBLIC_KEY_ID"
+  elif [[ "$1" == "encryption_key" ]]; then
+    gpg --batch --no-tty --quiet --symmetric --cipher-algo AES256 --passphrase "$ENCRYPTION_KEY"
+  else
+    cat
+  fi
 }
 
 # Function to upload backup to S3
 upload_to_s3() {
-	if [[ "$1" == "encrypted" ]]; then
-		# shellcheck disable=SC2086
-		aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz.gpg" $S3_STORAGE_CLASS_PARAMETER
-	else
-		# shellcheck disable=SC2086
-		aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz" $S3_STORAGE_CLASS_PARAMETER
-	fi
+  if [[ "$1" == "encrypted" ]]; then
+    # shellcheck disable=SC2086
+    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz.gpg" $S3_STORAGE_CLASS_PARAMETER
+  else
+    # shellcheck disable=SC2086
+    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz" $S3_STORAGE_CLASS_PARAMETER
+  fi
 }
 
 # Perform backup based on encryption method
 if [[ -n "$ENCRYPT_WITH_PUBLIC_KEY_ID" ]]; then
-	if gpg --quiet --keyserver "$KEYSERVER" --recv-keys "$ENCRYPT_WITH_PUBLIC_KEY_ID"; then
-		if create_tar_archive | encrypt_stream "public_key" | upload_to_s3 "encrypted"; then
-			echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
-		else
-			echo "Backup of $TARGET has failed. Please investigate the issue."
-			exit 1
-		fi
-	else
-		echo "Error: Failed to retrieve the public key from the keyserver."
-		exit 1
-	fi
+  if gpg --quiet --keyserver "$KEYSERVER" --recv-keys "$ENCRYPT_WITH_PUBLIC_KEY_ID"; then
+    if create_tar_archive | encrypt_stream "public_key" | upload_to_s3 "encrypted"; then
+      echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+    else
+      echo "Backup of $TARGET has failed. Please investigate the issue."
+      exit 1
+    fi
+  else
+    echo "Error: Failed to retrieve the public key from the keyserver."
+    exit 1
+  fi
 elif [[ -n "$ENCRYPTION_KEY" ]]; then
-	if create_tar_archive | encrypt_stream "encryption_key" | upload_to_s3 "encrypted"; then
-		echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
-	else
-		echo "Backup of $TARGET has failed. Please investigate the issue."
-		exit 1
-	fi
+  if create_tar_archive | encrypt_stream "encryption_key" | upload_to_s3 "encrypted"; then
+    echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+  else
+    echo "Backup of $TARGET has failed. Please investigate the issue."
+    exit 1
+  fi
 else
-	if create_tar_archive | encrypt_stream "no_encryption" | upload_to_s3 "unencrypted"; then
-		echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
-	else
-		echo "Backup of $TARGET has failed. Please investigate the issue."
-		exit 1
-	fi
+  if create_tar_archive | encrypt_stream "no_encryption" | upload_to_s3 "unencrypted"; then
+    echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+  else
+    echo "Backup of $TARGET has failed. Please investigate the issue."
+    exit 1
+  fi
 fi

--- a/backup.sh
+++ b/backup.sh
@@ -1,48 +1,94 @@
 #!/bin/bash
+
 set -eo pipefail
 [[ -n "$TRACE" ]] && set -x
 
+# Check if backup directory exists
 if [[ ! -d "/backup" ]]; then
   echo "Please mount a directory to backup with -v /backup:/backup"
   exit 1
 fi
 
-#Amazon S3 info
-AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-null}
-AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-null}
-AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-null}
-S3_STORAGE_CLASS=${S3_STORAGE_CLASS:-STANDARD}
+# Set default values for Amazon S3 info
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-null}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-null}"
+AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-null}"
+S3_STORAGE_CLASS="${S3_STORAGE_CLASS:-STANDARD}"
 
-BACKUP_NAME=${BACKUP_NAME:-backup}
-BUCKET_NAME=${BUCKET_NAME:-null}
+BACKUP_NAME="${BACKUP_NAME:-backup}"
+BUCKET_NAME="${BUCKET_NAME:-null}"
 
-#System info
-TIMESTAMP=$(date -u "+%Y-%m-%d-%H-%M-%S")
+# Set default keyserver (Ubuntu keyserver)
+KEYSERVER="${KEYSERVER:-hkp://keyserver.ubuntu.com}"
 
-### Build endpoint parameter if endpoint given
+# Set timestamp for backup
+TIMESTAMP="$(date -u "+%Y-%m-%d-%H-%M-%S")"
+
+# Build endpoint parameter if endpoint given
 if [[ -n "$ENDPOINT_URL" ]]; then
   ENDPOINT_URL_PARAMETER="--endpoint-url=$ENDPOINT_URL"
 fi
 
-### Setup AWS signature version if specified
+# Setup AWS signature version if specified
 if [[ -n "$AWS_SIGNATURE_VERSION" ]]; then
   aws configure set default.s3.signature_version "$AWS_SIGNATURE_VERSION"
 fi
 
-### Run backup to Amazon S3 Bucket
+# Set target directory for backup
 TARGET="backup/"
-if [[ -n "$ENCRYPTION_KEY" ]]; then
-  # shellcheck disable=SC2086
-  /bin/tar -czf - "$TARGET" | gpg --batch --no-tty -q -c --passphrase "$ENCRYPTION_KEY" | aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz.gpg" --storage-class $S3_STORAGE_CLASS
-else
-  # shellcheck disable=SC2086
-  /bin/tar -czf - "$TARGET" | aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz" --storage-class $S3_STORAGE_CLASS
-fi
 
-# shellcheck disable=SC2181
-if [[ "$?" -eq "0" ]]; then
-  echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+# Function to create a tar archive of the target directory
+create_tar_archive() {
+  tar --create --gzip --file - "$TARGET"
+}
+
+# Function to encrypt the input stream
+encrypt_stream() {
+  if [[ "$1" == "public_key" ]]; then
+    gpg --batch --no-tty --quiet --encrypt --always-trust --recipient "$ENCRYPT_WITH_PUBLIC_KEY_ID"
+  elif [[ "$1" == "encryption_key" ]]; then
+    gpg --batch --no-tty --quiet --symmetric --cipher-algo AES256 --passphrase "$ENCRYPTION_KEY"
+  else
+    cat
+  fi
+}
+
+# Function to upload backup to S3
+upload_to_s3() {
+  if [[ "$1" == "encrypted" ]]; then
+    # shellcheck disable=SC2086
+    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz.gpg" --storage-class $S3_STORAGE_CLASS
+  else
+    # shellcheck disable=SC2086
+    aws $ENDPOINT_URL_PARAMETER s3 cp - "s3://$BUCKET_NAME/$BACKUP_NAME-$TIMESTAMP.tgz" --storage-class $S3_STORAGE_CLASS
+  fi
+}
+
+# Perform backup based on encryption method
+if [[ -n "$ENCRYPT_WITH_PUBLIC_KEY_ID" ]]; then
+  if gpg --quiet --keyserver "$KEYSERVER" --recv-keys "$ENCRYPT_WITH_PUBLIC_KEY_ID"; then
+    if create_tar_archive | encrypt_stream "public_key" | upload_to_s3 "encrypted"; then
+      echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+    else
+      echo "Backup of $TARGET has failed. Please investigate the issue."
+      exit 1
+    fi
+  else
+    echo "Error: Failed to retrieve the public key from the keyserver."
+    exit 1
+  fi
+elif [[ -n "$ENCRYPTION_KEY" ]]; then
+  if create_tar_archive | encrypt_stream "encryption_key" | upload_to_s3 "encrypted"; then
+    echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+  else
+    echo "Backup of $TARGET has failed. Please investigate the issue."
+    exit 1
+  fi
 else
-  echo "Backup of $TARGET has failed. Please look into this and find out what went wrong"
+  if create_tar_archive | encrypt_stream "no_encryption" | upload_to_s3 "unencrypted"; then
+    echo "$TIMESTAMP: The backup for $BACKUP_NAME finished successfully."
+  else
+    echo "Backup of $TARGET has failed. Please investigate the issue."
+    exit 1
+  fi
 fi
-### Finish Amazon backup


### PR DESCRIPTION
### What?
- [x] Allow using `ENCRYPT_WITH_PUBLIC_KEY_ID` env parameter to encrypt the backups with the User's GPG public key.
- [x] Update documentation accordingly.
- [x] [Extra] Allow using the S3-server default storage class (4b4508959f8cf5737c6d24dd817a1b89fefb5c76).
- [x] Fix the `shfmt` formatting.

### Why?
- By using asymmetric encryption, the data protection would still be insured even when a bad actor gains _read_ access to the `s3backup` service configs **_and_** the access to the S3 storage. When the said actor gains write access, it's still a game over for whoever's trying to protect that data.

### How to test?
- It's backward-compatible, so everything that works now should also work in this version.
-  1. Generate a new PGP key if you don't have one ([instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key)).
    1. Get your key ID (don't worry, it's public information).
        ```sh
        gpg --list-secret-keys --keyid-format long
        # [keyboxd]
        # ---------
        # sec   ed25519/7929C6D3BB256BCC 2024-03-22 [SC]
        #       5815326E1FAB78E966837F287929C6D3BB256BCC  <-- THIS IS YOUR KEY ID
        # uid                 [ultimate] Test Dokku Backup (one-time-key) <s3_backup_test@dokku.com>
        # ssb   cv25519/4A947B3B74A421B7 2024-03-22 [E]
        
        # export MY_PUBLIC_KEY_ID='5815326E1FAB78E966837F287929C6D3BB256BCC'
        ```
    1. Upload your keys to a keyserver:
        ```sh
        gpg --send-keys --keyserver keyserver.ubuntu.com $MY_PUBLIC_KEY_ID
        ```
    1. (assuming you have the environment variables loaded to your shell) Run:
        ```sh
        docker run -it \
            -e AWS_ACCESS_KEY_ID=ID \
            -e AWS_SECRET_ACCESS_KEY=KEY \
            -e BUCKET_NAME=backups \
            -e BACKUP_NAME=backup \
            -e ENCRYPT_WITH_PUBLIC_KEY_ID=$MY_PUBLIC_KEY_ID \
            -v /path/to/backup:/backup dokku/s3backup
        ```
        
### Anything else?
- Practise shows that Ubuntu's keyserver is sometimes buggy when it comes to uploading your public keys. So it might take some time (or you might use any other keyserver by passing the `-e KEYSERVER=$YOUR_KEYSERVER` to the `docker run` command.